### PR TITLE
Ship windbag as a Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "windbag",
+  "owner": {
+    "name": "Harry Plumer"
+  },
+  "plugins": [
+    {
+      "name": "windbag",
+      "source": "./plugin",
+      "description": "Catches AI-slop comments as they are written, not at commit time."
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -17,9 +17,20 @@ A pre-commit linter that catches comments narrating a change — a ticket number
 
 ## Install
 
+Needs a Rust toolchain. If you don't have one:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+. "$HOME/.cargo/env"    # and add this line to ~/.zshrc
+```
+
+Then, from a checkout:
+
 ```bash
 cargo install --path .
 ```
+
+That puts `windbag` in `~/.cargo/bin`, which must be on your `PATH`.
 
 ## Use
 
@@ -28,6 +39,7 @@ windbag init                  # write windbag.toml with generic defaults
 windbag check --staged        # check what's about to be committed
 windbag check --all           # check every git-tracked file in the repo
 windbag check --json --staged # machine-readable output
+windbag check --new-only f.py # only comments on lines the working tree adds over HEAD
 ```
 
 Pre-commit:
@@ -44,6 +56,68 @@ Pre-commit:
 ```
 
 (`windbag` needs to already be on `PATH` — `language: system` doesn't install it for you.)
+
+## Claude Code plugin
+
+Pre-commit catches slop after it's written. The plugin catches it as it's
+written: a `PostToolUse` hook runs `windbag` on every file Claude edits and
+exits non-zero on a violation, so the findings go straight back to Claude as a
+blocking error and it rewrites the comment before moving on. A `SessionStart`
+hook states the rules up front so most edits never trip the linter at all.
+
+```
+/plugin marketplace add scalevp-investment-ops/windbag
+/plugin install windbag@windbag
+```
+
+The binary has to be on `PATH` too — the plugin ships the hooks, not the linter,
+and they exit quietly when they can't find it. That means a Rust toolchain
+(see [Install](#install)) plus:
+
+```bash
+cargo install --git https://github.com/scalevp-investment-ops/windbag
+```
+
+TODO: publish prebuilt macOS binaries from a tagged release so installing this
+doesn't require a Rust toolchain. Fine while it's a couple of people; not fine
+as a team-wide ask.
+
+To turn it on for everyone working in a given repo, commit this to that repo's
+`.claude/settings.json`. Anyone who opens the repo is prompted to trust the
+marketplace, and the hooks apply from their next session:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "windbag": {
+      "source": { "source": "github", "repo": "scalevp-investment-ops/windbag" }
+    }
+  },
+  "enabledPlugins": { "windbag@windbag": true }
+}
+```
+
+Working on the plugin itself? `/plugin marketplace add /path/to/windbag` points
+at a local checkout instead. Either way the install copies [`plugin/`](plugin/)
+into `~/.claude/plugins/cache/` — keeping it out of the repo root is what keeps
+`target/` out of the copy. That copy is a snapshot: after editing a hook,
+reinstall to pick up the change.
+
+The hook needs `windbag` on `PATH` (or `WINDBAG_BIN` set) and `jq` installed;
+without either it exits quietly rather than breaking the session.
+
+| Env var | Effect |
+|---|---|
+| `WINDBAG_HOOK=off` | Disable both hooks without uninstalling. |
+| `WINDBAG_HOOK_LEVEL=error` | Block only on `error` rules; ignore warnings. |
+| `WINDBAG_BIN` | Explicit path to the binary. |
+
+Only comments on lines the working tree adds over `HEAD` are reported, so
+editing a file doesn't re-litigate comments that were already there. Claude is
+told not to silence a rule with `windbag: ignore` on its own — a false positive
+should surface to you, not get suppressed.
+
+`/windbag` sweeps the whole repo and fixes what it finds.
 
 Suppress a false positive inline:
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "windbag",
+  "description": "Blocks Claude Code from writing comments that narrate a change instead of documenting a constraint. Runs windbag on every file Claude edits and hands the violations back for an immediate rewrite.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Harry Plumer"
+  },
+  "license": "MIT"
+}

--- a/plugin/commands/windbag.md
+++ b/plugin/commands/windbag.md
@@ -1,0 +1,12 @@
+---
+description: Run windbag across the repo and clean up what it flags
+allowed-tools: Bash(windbag:*), Read, Edit
+---
+
+Run `windbag check --all` in the project root.
+
+For each violation, rewrite the comment to state the constraint that makes the
+current code correct, or delete it if there is no such constraint. Never add a
+`windbag: ignore` suppression without asking first.
+
+Report what you changed, grouped by rule.

--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -1,0 +1,27 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/windbag-post-edit.sh",
+            "timeout": 20
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/windbag-session-start.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugin/hooks/windbag-post-edit.sh
+++ b/plugin/hooks/windbag-post-edit.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# PostToolUse hook: lint the file Claude just wrote and, on a violation, exit 2
+# so the findings land back in Claude's context as a blocking error.
+#
+# Env:
+#   WINDBAG_HOOK=off            disable without uninstalling the plugin
+#   WINDBAG_HOOK_LEVEL=error    block on error-severity rules only (default: any)
+#   WINDBAG_BIN=/path/to/windbag
+set -uo pipefail
+
+[[ "${WINDBAG_HOOK:-on}" == "off" ]] && exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+payload=$(cat)
+file_path=$(printf '%s' "$payload" | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty')
+[[ -z "$file_path" || ! -f "$file_path" ]] && exit 0
+
+project_dir=$(printf '%s' "$payload" | jq -r '.cwd // empty')
+[[ -n "$project_dir" && -d "$project_dir" ]] && cd "$project_dir" || exit 0
+
+bin="${WINDBAG_BIN:-}"
+if [[ -z "$bin" ]]; then
+  for candidate in \
+    "$(command -v windbag 2>/dev/null)" \
+    "$HOME/.cargo/bin/windbag" \
+    "${CLAUDE_PLUGIN_ROOT:-}/target/release/windbag"; do
+    [[ -n "$candidate" && -x "$candidate" ]] && bin="$candidate" && break
+  done
+fi
+[[ -z "$bin" ]] && exit 0
+
+# Relative to the project dir so the report reads like the rest of the tool's
+# output; a file outside it stays absolute.
+rel_path="${file_path#"$project_dir"/}"
+
+report=$("$bin" check --new-only --json "$rel_path" 2>/dev/null)
+printf '%s' "$report" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1 || exit 0
+
+if [[ "${WINDBAG_HOOK_LEVEL:-any}" == "error" ]]; then
+  printf '%s' "$report" | jq -e 'map(select(.severity == "error")) | length > 0' >/dev/null 2>&1 || exit 0
+fi
+
+{
+  echo "windbag flagged comments you just wrote in ${rel_path}:"
+  echo
+  printf '%s' "$report" | jq -r '.[] | "  \(.file):\(.line)  \(.severity)  \(.rule)  \(.message)"'
+  echo
+  echo "Rewrite each flagged comment to state the constraint that makes the current code correct — or delete it if there is no such constraint. Change-history, ticket numbers, and hedging belong in the commit message, not the file. Do not add a 'windbag: ignore' suppression unless the user asked for one."
+} >&2
+exit 2

--- a/plugin/hooks/windbag-session-start.sh
+++ b/plugin/hooks/windbag-session-start.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SessionStart hook: state the comment rules up front so Claude writes clean
+# comments in the first place. The PostToolUse hook is the backstop, not the
+# only line of defence — a caught violation costs an extra edit round-trip.
+set -uo pipefail
+
+[[ "${WINDBAG_HOOK:-on}" == "off" ]] && exit 0
+
+read -r -d '' context <<'EOF'
+This project lints comments with `windbag`, and a PostToolUse hook will block
+your edits when it finds a violation. Write comments accordingly:
+
+- A comment documents the constraint that makes the current code correct. It
+  does not narrate the change that produced it.
+- No ticket IDs in comments (`SCA-533`). `TODO(SCA-600):` for a forward-looking
+  tracked task is fine.
+- No change history: "was missing", "used to be", "no longer", "this fix",
+  "silently swallows".
+- No hedging: "should work", "not sure why", "I believe", "hopefully". If you
+  are unsure whether code is correct, say so to the user instead.
+- No comment that restates the line below it.
+- No pointers to another file and line — they rot.
+- Keep comment blocks short relative to the code they document.
+
+If a rule fires on a comment that is genuinely correct, say so and ask before
+suppressing it with `windbag: ignore[RULE]`.
+EOF
+
+jq -n --arg ctx "$context" \
+  '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}' 2>/dev/null \
+  || printf '%s\n' "$context"

--- a/src/git.rs
+++ b/src/git.rs
@@ -67,6 +67,30 @@ pub fn added_lines(repo_root: &Path, file: &Path) -> anyhow::Result<HashSet<usiz
     Ok(parse_added_lines(&out))
 }
 
+/// 1-indexed line numbers the working tree adds on top of `HEAD` for `file`,
+/// staged or not. `None` means "no baseline to diff against" — an untracked
+/// file is new in its entirety, and so is every line in it.
+pub fn working_tree_added_lines(
+    repo_root: &Path,
+    file: &Path,
+) -> anyhow::Result<Option<HashSet<usize>>> {
+    let spec = file.to_string_lossy().into_owned();
+    let tracked = Command::new("git")
+        .current_dir(repo_root)
+        .args(["ls-files", "--error-unmatch", "--", &spec])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !tracked {
+        return Ok(None);
+    }
+    let out = run(
+        repo_root,
+        &["diff", "HEAD", "-U0", "--no-color", "--", &spec],
+    )?;
+    Ok(Some(parse_added_lines(&out)))
+}
+
 fn parse_added_lines(diff: &str) -> HashSet<usize> {
     let mut lines = HashSet::new();
     let mut current: Option<usize> = None;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,11 @@ enum Commands {
         /// Check every git-tracked file in the repo
         #[arg(long)]
         all: bool,
+        /// With explicit paths: report only comment blocks touching a line the
+        /// working tree adds on top of HEAD. Lets an editor-integration hook
+        /// flag what was just written without re-litigating the whole file.
+        #[arg(long, requires = "paths")]
+        new_only: bool,
         /// Emit machine-readable JSON instead of human-readable text
         #[arg(long)]
         json: bool,
@@ -48,9 +53,10 @@ fn main() -> anyhow::Result<()> {
             paths,
             staged,
             all,
+            new_only,
             json,
             config,
-        } => run_check(paths, staged, all, json, &config),
+        } => run_check(paths, staged, all, new_only, json, &config),
         Commands::Init => run_init(),
     }
 }
@@ -101,6 +107,7 @@ fn run_check(
     paths: Vec<PathBuf>,
     staged: bool,
     all: bool,
+    new_only: bool,
     json: bool,
     config_path: &Path,
 ) -> anyhow::Result<()> {
@@ -121,6 +128,15 @@ fn run_check(
     let mut violations = Vec::new();
 
     if !paths.is_empty() {
+        // A path outside any repo, or a repo-less directory, just means no
+        // baseline: every line is treated as new rather than erroring out.
+        let root = if new_only {
+            std::env::current_dir()
+                .ok()
+                .and_then(|d| git::repo_root(&d).ok())
+        } else {
+            None
+        };
         for path in &paths {
             if is_excluded(path, &exclude_patterns) {
                 continue;
@@ -129,7 +145,17 @@ fn run_check(
                 continue;
             };
             let source = std::fs::read_to_string(path)?;
-            violations.extend(check_source(path, &source, language, &config, None));
+            let added = match &root {
+                Some(root) => git::working_tree_added_lines(root, path).unwrap_or(None),
+                None => None,
+            };
+            violations.extend(check_source(
+                path,
+                &source,
+                language,
+                &config,
+                added.as_ref(),
+            ));
         }
     } else {
         let cwd = std::env::current_dir()?;


### PR DESCRIPTION
Pre-commit catches slop after Claude has already written it, moved on, and lost the context. This moves enforcement to the edit itself.

## How it works

- **`PostToolUse` hook** on `Edit|Write|MultiEdit|NotebookEdit` runs `windbag` on the file just written. On a violation it prints the findings to stderr and exits 2 — the exit code Claude Code feeds back to the model as a blocking error — so Claude rewrites the comment before moving on.
- **`SessionStart` hook** states the comment rules up front, so most edits never trip the linter at all. This is the cheap layer; the linter is the backstop.
- **`/windbag`** sweeps the whole repo and fixes what it finds.

Claude is explicitly told not to silence a rule with `windbag: ignore` on its own — otherwise the obvious escape hatch is to suppress rather than rewrite. A false positive should surface to a human.

## New flag: `check --new-only`

Explicit-path mode checked the whole file, so the hook would have nagged about comments Claude never touched. `--new-only` restricts reporting to comment blocks overlapping a line the working tree adds over `HEAD`, mirroring the existing `--staged` logic via a new `git::working_tree_added_lines`. Untracked files have no baseline, so every line counts as new.

## Layout

The plugin lives in `plugin/` rather than the repo root. Installing copies the source directory into `~/.claude/plugins/cache/`, and plugin packaging does not respect `.gitignore` — from the root that produced a **616MB** copy of `target/`. From `plugin/` it's **20KB**.

## Testing

- `cargo test` (15 pass), `cargo fmt --check`, `cargo clippy --all-targets` all clean; `windbag check --all` still dogfoods to zero violations.
- `--new-only` verified against a real repo with one committed slop comment and one freshly written: whole-file mode reports both, `--new-only` reports only the new one.
- Hook exits 0 on every pass-through path — clean file, warnings-only under `WINDBAG_HOOK_LEVEL=error`, `WINDBAG_HOOK=off`, missing binary, missing `jq`, no `file_path` in the payload.
- Installed and driven live in two fresh headless sessions. Given a prompt demanding an exact slop comment, the hook blocked and Claude surfaced the violations rather than suppressing them. Given a normal prompt, it never wrote the bad comment at all and the result passed clean.

## Known gap

Installing requires a Rust toolchain (`cargo install --git ...`). Fine for a couple of people, not fine as a team-wide ask — publishing prebuilt macOS binaries from a tagged release is left as a TODO in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)