### PR TITLE
Pilot: aristo intent claims on three pure functions

### DIFF
--- a/.aristo/doc/windbag_diff_added_lines.md
+++ b/.aristo/doc/windbag_diff_added_lines.md
@@ -1,0 +1,7 @@
+**Aristo verified intent — `windbag_diff_added_lines`**
+
+returns the 1-indexed line numbers of every `+` line in a unified diff, tracked via each hunk's `+start,count` header
+
+<sub>Verify level: **neural**</sub>
+
+---

--- a/.aristo/doc/windbag_phrase_word_boundary.md
+++ b/.aristo/doc/windbag_phrase_word_boundary.md
@@ -1,0 +1,7 @@
+**Aristo verified intent — `windbag_phrase_word_boundary`**
+
+true iff phrase occurs in lower_haystack as a whole word (bounded by \b), not as a substring of a longer token
+
+<sub>Verify level: **neural**</sub>
+
+---

--- a/.aristo/doc/windbag_todo_marker_window.md
+++ b/.aristo/doc/windbag_todo_marker_window.md
@@ -1,0 +1,7 @@
+**Aristo verified intent — `windbag_todo_marker_window`**
+
+true iff a forward-looking task-marker prefix appears, case-insensitively, within the fixed lookback window before match_start
+
+<sub>Verify level: **neural**</sub>
+
+---

--- a/.aristo/proofs/windbag_diff_added_lines.proof
+++ b/.aristo/proofs/windbag_diff_added_lines.proof
@@ -1,0 +1,31 @@
+[verdict]
+type = "verified"
+method = "neural"
+produced_at_text_hash = "sha256:b2406c4f88af512e2fc5e511257525a43ae97419d0e42591526adaa38205db26"
+produced_at_body_hash = "sha256:abe8f8f05f5d8d9030e61cf02a5372754f136bf0822b5c97a64dc6fb8d789065"
+produced_by = "claude-code-adhoc (no aristo-verify skill installed; CLI invoked directly)"
+verifier_model = "claude-sonnet-5"
+attempts = 1
+property_kind = "postcondition"
+
+[verified.proof]
+conclusion = "parse_added_lines returns the set of 1-indexed line numbers of every line beginning with '+' in a unified diff (excluding the '+++' file-header line), computed by tracking a running line counter seeded from each hunk's '+start,count' header."
+
+[[verified.proof.steps]]
+path = "0"
+claim = "on a '@@ ' hunk header, current is set to the integer before the first ',' after the '+' in the header (defaulting to 0 on any parse failure); '+++' lines are skipped explicitly; every other line starting with '+' inserts the current counter into the result set and increments it."
+relation_to_parent = "decomposes"
+
+[[verified.proof.steps.grounds]]
+kind = "code"
+file = "src/git.rs"
+lines = "99-120"
+code_text_hash = "sha256:2be98f75112b43dbea133846a2b4e6f0c1f4b386b5069e67a539610183256f17"
+reason = "direct read of the function body confirms the hunk-header parse, the '+++' exclusion, and the insert-then-increment loop are the only paths that populate the returned HashSet."
+
+[[verified.proof.steps.grounds]]
+kind = "code"
+file = "src/git.rs"
+lines = "126-153"
+code_text_hash = "sha256:273b9f20d3639d50420346a5a2cdbe7fbdcf0aff886dcc678d6a8bc90c498d84"
+reason = "existing unit tests parses_simple_hunk and parses_multiple_hunks assert the exact output sets for representative single- and multi-hunk diffs, and both pass under cargo test."

--- a/.aristo/proofs/windbag_phrase_word_boundary.proof
+++ b/.aristo/proofs/windbag_phrase_word_boundary.proof
@@ -1,0 +1,24 @@
+[verdict]
+type = "verified"
+method = "neural"
+produced_at_text_hash = "sha256:f57c1794219f994158293202d66e0c3bcad655ba2db48b4d4c2d198b9c4273c0"
+produced_at_body_hash = "sha256:8815ac308ec917c2b5ac78be58e9e84cce70c487b26a45974a49de6d9cc2e2b3"
+produced_by = "claude-code-adhoc (no aristo-verify skill installed; CLI invoked directly)"
+verifier_model = "claude-sonnet-5"
+attempts = 1
+property_kind = "postcondition"
+
+[verified.proof]
+conclusion = 'contains_phrase returns true iff phrase matches lower_haystack as a whole word, i.e. bounded by \b on both sides, not merely as a substring.'
+
+[[verified.proof.steps]]
+path = "0"
+claim = 'the function builds the pattern \b<escaped phrase>\b via regex::escape (so regex metacharacters in phrase are treated literally) and returns whether that pattern matches lower_haystack; a construction failure (not expected for an escaped literal) degrades to false via unwrap_or(false) rather than panicking.'
+relation_to_parent = "decomposes"
+
+[[verified.proof.steps.grounds]]
+kind = "code"
+file = "src/rules.rs"
+lines = "149-154"
+code_text_hash = "sha256:bc7155748b1e9f97d198af5ad02ac77dad6c263ab5f4f7981b0b68e02cfc7c0b"
+reason = '''direct read of the function body: \b anchors on both sides of the escaped phrase are exactly what makes this word-boundary rather than substring matching, matching the claim's explicit contrast with a plain substring check.'''

--- a/.aristo/proofs/windbag_todo_marker_window.proof
+++ b/.aristo/proofs/windbag_todo_marker_window.proof
@@ -1,0 +1,24 @@
+[verdict]
+type = "verified"
+method = "neural"
+produced_at_text_hash = "sha256:23c93b31e593b024023bb2d9d2ba7a4eeac233827fbd1ebc2331e0177694d759"
+produced_at_body_hash = "sha256:e3cb1cc717bfec404d12a175e8ce1b8eda9ad688518fc4389a9846764cc43b84"
+produced_by = "claude-code-adhoc (no aristo-verify skill installed; CLI invoked directly)"
+verifier_model = "claude-sonnet-5"
+attempts = 1
+property_kind = "postcondition"
+
+[verified.proof]
+conclusion = 'precedes_with_todo_marker returns true iff the case-insensitive substring "todo" or "fixme" occurs anywhere in the TODO_MARKER_WINDOW (20) characters immediately preceding match_start, char-boundary clamped.'
+
+[[verified.proof.steps]]
+path = "0"
+claim = 'window_start is match_start.saturating_sub(20) floored to a char boundary; window is text[window_start..match_start].to_lowercase(); the function returns window.contains("todo") || window.contains("fixme").'
+relation_to_parent = "decomposes"
+
+[[verified.proof.steps.grounds]]
+kind = "code"
+file = "src/rules.rs"
+lines = "128-132"
+code_text_hash = "sha256:1c4b6a9581a18a3c4ab0c296b28424c9115bc52bf09953596c7f35c379469c13"
+reason = "direct read of the function body: saturating_sub avoids underflow near the start of text, floor_char_boundary avoids slicing mid-codepoint, and the two contains() calls are the only source of the boolean result."

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,15 @@
 /target
+
+# Aristo runtime, cache, and per-user state: never commit these.
+# Durable state (.aristo/proofs/*.proof, .aristo/doc/, .aristo/specs/,
+# .aristo/feedback/, .aristo/expectations.toml, .aristo/canon-matches.toml,
+# aristo.toml) is committed and intentionally not listed here.
+.aristo/index.toml
+.aristo/catalogue.json
+.aristo/sessions/
+.aristo/nudge-state.toml
+.aristo/verify-queue/
+.aristo/critique-queue/
+.aristo/critiques/
+.aristo/proofs/*.proof.bak
+.aristo/archive/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "aristo"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e113982ba9b01cf18f5e4865b77c6578f374bb1d25596a3d8f7e301902c4668"
+dependencies = [
+ "aristo-macros",
+]
+
+[[package]]
+name = "aristo-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545863554d59c65fa0f5824a2992b140021975bcf3975287113ad9e8ec2cb68e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,7 +140,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -331,7 +351,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -374,6 +394,17 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -527,6 +558,7 @@ name = "windbag"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aristo",
  "clap",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
 anyhow = "1"
+aristo = "0.6.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/aristo.toml
+++ b/aristo.toml
@@ -1,0 +1,33 @@
+[verify.cache]
+strategy = "local"
+commit_specs = true
+
+[stamp]
+hooks = "pre-commit"
+hash_crate_root = false
+
+[telemetry]
+enabled = false
+
+[lint]
+pre_commit = "check"
+strict = false
+
+[corpus]
+contribute = false
+
+[doc]
+commit_artifacts = true
+position = "before"
+
+[index]
+
+[canon]
+enabled = false
+threshold_stamp = 0.85
+threshold_critique = 0.65
+
+[nudges]
+aggressiveness = "medium"
+
+[instance]

--- a/src/git.rs
+++ b/src/git.rs
@@ -91,6 +91,11 @@ pub fn working_tree_added_lines(
     Ok(Some(parse_added_lines(&out)))
 }
 
+#[aristo::intent(
+    "returns the 1-indexed line numbers of every `+` line in a unified diff, tracked via each hunk's `+start,count` header",
+    verify = "neural",
+    id = "windbag_diff_added_lines",
+)]
 fn parse_added_lines(diff: &str) -> HashSet<usize> {
     let mut lines = HashSet::new();
     let mut current: Option<usize> = None;

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -120,6 +120,11 @@ const TODO_MARKER_WINDOW: usize = 20;
 /// characters immediately before a ticket-ID match — the shape of a
 /// forward-looking tracked task (`TODO(SCA-600): ...`, `FIXME: SCA-600 ...`)
 /// rather than the backward-narrating pattern TICKET_ID targets.
+#[aristo::intent(
+    "true iff a forward-looking task-marker prefix appears, case-insensitively, within the fixed lookback window before match_start",
+    verify = "neural",
+    id = "windbag_todo_marker_window",
+)]
 fn precedes_with_todo_marker(text: &str, match_start: usize) -> bool {
     let window_start = floor_char_boundary(text, match_start.saturating_sub(TODO_MARKER_WINDOW));
     let window = text[window_start..match_start].to_lowercase();
@@ -136,6 +141,11 @@ fn floor_char_boundary(s: &str, mut idx: usize) -> usize {
 /// Word-boundary-aware phrase match — a naive substring check let a
 /// first-person hedge phrase fire inside an unrelated identifier ending
 /// in the same two letters, found during calibration against real code.
+#[aristo::intent(
+    "true iff phrase occurs in lower_haystack as a whole word (bounded by \\b), not as a substring of a longer token",
+    verify = "neural",
+    id = "windbag_phrase_word_boundary",
+)]
 fn contains_phrase(lower_haystack: &str, phrase: &str) -> bool {
     let pattern = format!(r"\b{}\b", regex::escape(phrase));
     Regex::new(&pattern)


### PR DESCRIPTION
## What this does

Adds `aristo` (https://github.com/aretta-ai/aristo) as a macro-only dependency and puts `#[aristo::intent]` claims on three small, pure functions with a precise behavioral contract:

- `precedes_with_todo_marker` (src/rules.rs)
- `contains_phrase` (src/rules.rs)
- `parse_added_lines` (src/git.rs)

Aristo hashes each claim + function body and flags drift when a later edit changes the body without updating the claim. This is a different check than windbag's own comment linter runs: windbag checks comment prose, not whether a function's behavior still matches what a comment or claim says it does.

## Scope

- All three claims use `verify = "neural"`. Aristo's README lists this tier under "Free, now" / offline; `verify = "full"` (tests through formal proofs, via Aretta's backend) is listed as "design partners" only and is not used here.
- `[canon] enabled = false` in `aristo.toml`. `aristo init` generates this as `true` by default; canon-matching queries Aretta's hosted service once a user runs `aristo auth`. Disabled here so no source leaves the machine regardless of future `auth` state.
- No `--ci` / `--ci-verify` on `aristo init` — does not add the upstream `aristo-action` to CI or require an `ARETTA_TOKEN` secret.
- No git hook installed — `aristo init --hook` is deprecated and off by default upstream; `.aristo/index.toml` is a gitignored local cache, not a commit-time gate.
- Claims are indexed and pass `aristo lint --check --strict` and `aristo verify --audit` (documented by the CLI as no-dispatch/no-network). They are not yet verified: `aristo verify`'s bare invocation references dispatching a "canon-verify session" in its own `--help` text, which is not documented as network-free, so that step was not run.

## Verification run

- `cargo build`, `cargo test`: 15/15 pass, unchanged.
- `aristo lint --check --strict`: 0 findings.
- `aristo index`, `aristo verify --audit`: 3 annotations, 0 stale/refuted/orphan.

## Aristo version info

`aristo` 0.6.1, first published to crates.io 2026-05-29, 20 releases since. Upstream README marks the project "Alpha."
