### PR TITLE
Check comments in YAML, HTML, and Markdown

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,4 +7,4 @@ repos:
         entry: windbag check --staged
         language: system
         pass_filenames: false
-        types_or: [python, javascript, jsx, ts, tsx, terraform, rust]
+        types_or: [python, javascript, jsx, ts, tsx, terraform, rust, yaml, markdown, html]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,4 +4,4 @@
   entry: windbag check --staged
   language: system
   pass_filenames: false
-  types_or: [python, javascript, jsx, ts, tsx, terraform, rust]
+  types_or: [python, javascript, jsx, ts, tsx, terraform, rust, yaml, markdown, html]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-html"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261b708e5d92061ede329babaaa427b819329a9d427a1d710abb0f67bbef63ee"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-javascript"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +521,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-yaml"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,10 +555,12 @@ dependencies = [
  "toml",
  "tree-sitter",
  "tree-sitter-hcl",
+ "tree-sitter-html",
  "tree-sitter-javascript",
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
+ "tree-sitter-yaml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
 anyhow = "1"
+tree-sitter-html = "0.23"
+tree-sitter-yaml = "0.7"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # windbag
 
-A pre-commit linter that catches comments narrating a change — a ticket number, what the code used to do, hedging about whether it works — instead of documenting why the current code is the way it is. Checks Python, JavaScript/TypeScript, Terraform/HCL, and Rust.
+A pre-commit linter that catches comments narrating a change — a ticket number, what the code used to do, hedging about whether it works — instead of documenting why the current code is the way it is. Checks Python, JavaScript/TypeScript, Terraform/HCL, and Rust, plus the markup formats that carry comments: YAML, HTML, and Markdown.
 
 ## What it detects
 
@@ -9,11 +9,23 @@ A pre-commit linter that catches comments narrating a change — a ticket number
 | `TICKET_ID` | error | A ticket ID in a comment (`SCA-533`). Exempts `TODO(SCA-600)`-style tracked tasks and security-advisory IDs (`CVE-`, `GHSA-`, ...). |
 | `HISTORY_NARRATION` | error | "was missing", "used to be", "no longer", "silently swallows", and similar. |
 | `HEDGE_LANGUAGE` | error | "should work", "hopefully", "not sure why", "i believe", and similar. |
-| `CROSS_FILE_REF` | warn | A pointer to another file/line (`handler.py:147`). |
-| `VERBOSE_COMMENT` | warn | A comment that's long relative to what it documents. |
+| `CROSS_FILE_REF` | warn | A pointer to another file/line (`handler.py:147`). Documentation URLs are exempt. |
+| `VERBOSE_COMMENT` | warn | A comment that's long relative to what it documents. Markup files are exempt. |
 | `OBVIOUS_COMMENT` | warn | A comment that just restates the line below it (`// increment the counter` above `counter += 1`). |
 
 `error` rules fail the check; `warn` rules are reported but don't block.
+
+## Markup files
+
+YAML comments (`#`) come from the YAML grammar, so a `#` inside a quoted
+scalar stays data rather than becoming a comment. HTML and Markdown are
+checked through `<!-- ... -->`; in Markdown, anything inside a fenced code
+block is sample markup, not a comment, and is skipped.
+
+The content rules — `TICKET_ID`, `HISTORY_NARRATION`, `HEDGE_LANGUAGE`,
+`CROSS_FILE_REF` — carry the weight here. `VERBOSE_COMMENT` does not apply:
+a few lines of explanation above a one-line config key is the idiomatic
+shape in a config file, not a comment outgrowing its code.
 
 ## Install
 
@@ -52,7 +64,7 @@ Pre-commit:
       entry: windbag check --staged
       language: system
       pass_filenames: false
-      types_or: [python, javascript, jsx, ts, tsx, terraform, rust]
+      types_or: [python, javascript, jsx, ts, tsx, terraform, rust, yaml, markdown, html]
 ```
 
 (`windbag` needs to already be on `PATH` — `language: system` doesn't install it for you.)
@@ -157,6 +169,25 @@ schedule_followup()
 # Sorted DESC because the caller assumes the first row is newest.  <- clean, real WHY
 return sorted(items, reverse=True)
 ```
+
+```yaml
+# Was missing (SCA-533): the deploy no longer fails.  <- TICKET_ID, HISTORY_NARRATION
+steps:
+  - checkout
+
+# Pinned because the orb syntax below requires 2.1.   <- clean, real WHY
+version: 2.1
+```
+
+In Markdown, a comment shown as sample markup inside a fence is content:
+
+````markdown
+<!-- Was missing (SCA-533): renders wrong without it. -->   <- TICKET_ID, HISTORY_NARRATION
+
+```html
+<!-- Was missing (SCA-901): this one is an example. -->     <- clean, inside a fence
+```
+````
 
 ## License
 

--- a/src/comments.rs
+++ b/src/comments.rs
@@ -21,6 +21,9 @@ pub struct CommentBlock {
     /// compare what the comment says against what the code actually does.
     pub attached_code_text: Option<String>,
     pub is_doc_comment: bool,
+    /// Whether the comment came from a markup file, which
+    /// `Language::is_markup` explains.
+    pub is_markup: bool,
 }
 
 fn collect_comment_nodes<'a>(node: Node<'a>, out: &mut Vec<Node<'a>>) {
@@ -34,12 +37,25 @@ fn collect_comment_nodes<'a>(node: Node<'a>, out: &mut Vec<Node<'a>>) {
     }
 }
 
-/// Extracts comment blocks from `source`. Consecutive comment nodes
-/// (no blank or code line between them) are merged into a single block,
-/// matching how a human reads a paragraph-style comment as one unit.
+/// Extracts comment blocks from `source`. Consecutive comments (no blank
+/// or code line between them) are merged into a single block, matching how
+/// a human reads a paragraph-style comment as one unit.
 pub fn extract_blocks(source: &str, language: Language) -> anyhow::Result<Vec<CommentBlock>> {
+    match language.ts_language() {
+        Some(ts_language) => extract_treesitter_blocks(source, &ts_language, language),
+        // Markdown, whose `<!-- -->` shares an `html_block` node with
+        // `<div>`/`<script>` in the grammar and needs a sharper separation.
+        None => Ok(scan_html_comments(source)),
+    }
+}
+
+fn extract_treesitter_blocks(
+    source: &str,
+    ts_language: &tree_sitter::Language,
+    language: Language,
+) -> anyhow::Result<Vec<CommentBlock>> {
     let mut parser = Parser::new();
-    parser.set_language(&language.ts_language())?;
+    parser.set_language(ts_language)?;
     let tree = parser
         .parse(source, None)
         .ok_or_else(|| anyhow::anyhow!("tree-sitter failed to parse source"))?;
@@ -80,6 +96,7 @@ pub fn extract_blocks(source: &str, language: Language) -> anyhow::Result<Vec<Co
             attached_code_lines,
             attached_code_text,
             is_doc_comment,
+            is_markup: language.is_markup(),
         });
         i = j;
     }
@@ -101,5 +118,153 @@ fn attached_sibling_info(
             (span, Some(node_text(source, &sibling)))
         }
         _ => (0, None),
+    }
+}
+
+const OPEN: &str = "<!--";
+const CLOSE: &str = "-->";
+
+/// Byte ranges covered by fenced code blocks, fence lines included, so a
+/// `<!-- -->` shown as sample markup inside one is content rather than a
+/// comment.
+fn fenced_ranges(source: &str) -> Vec<std::ops::Range<usize>> {
+    let mut ranges = Vec::new();
+    let mut open: Option<(char, usize, usize)> = None;
+    let mut offset = 0usize;
+    for line in source.split_inclusive('\n') {
+        let line_end = offset + line.len();
+        if let Some(fence) = fence_marker(line) {
+            match open {
+                // A closing fence matches the opening character, runs at
+                // least as long, and carries no info string.
+                Some((open_ch, open_len, start))
+                    if fence.ch == open_ch && fence.run >= open_len && !fence.has_info =>
+                {
+                    ranges.push(start..line_end);
+                    open = None;
+                }
+                None if fence.opens() => open = Some((fence.ch, fence.run, offset)),
+                _ => {}
+            }
+        }
+        offset = line_end;
+    }
+    // An unclosed fence runs to end of file, the way a renderer treats it.
+    if let Some((_, _, start)) = open {
+        ranges.push(start..source.len());
+    }
+    ranges
+}
+
+struct Fence {
+    ch: char,
+    run: usize,
+    has_info: bool,
+    /// A backtick info string may not contain a backtick, which is what
+    /// keeps an inline span like ```` ``a `b` `` ```` from opening a block.
+    info_has_backtick: bool,
+}
+
+impl Fence {
+    fn opens(&self) -> bool {
+        !(self.ch == '`' && self.info_has_backtick)
+    }
+}
+
+/// The fence run on a line: up to three spaces of indent, then three or
+/// more backticks or tildes.
+fn fence_marker(line: &str) -> Option<Fence> {
+    let indent = line.len() - line.trim_start_matches(' ').len();
+    if indent > 3 {
+        return None;
+    }
+    let rest = &line[indent..];
+    let ch = rest.chars().next()?;
+    if ch != '`' && ch != '~' {
+        return None;
+    }
+    let run = rest.chars().take_while(|c| *c == ch).count();
+    if run < 3 {
+        return None;
+    }
+    let info = rest[run..].trim();
+    Some(Fence {
+        ch,
+        run,
+        has_info: !info.is_empty(),
+        info_has_backtick: info.contains('`'),
+    })
+}
+
+/// Extracts `<!-- ... -->` comments, skipping anything inside a fenced
+/// code block, and merges runs that sit on consecutive lines. Documentation
+/// routinely shows a comment as sample markup inside a fence, so the fence
+/// bounds are what separates a comment from content here.
+fn scan_html_comments(source: &str) -> Vec<CommentBlock> {
+    let fenced = fenced_ranges(source);
+    let line_of = LineIndex::new(source);
+
+    let mut blocks: Vec<CommentBlock> = Vec::new();
+    let mut pos = 0usize;
+    while let Some(rel) = source[pos..].find(OPEN) {
+        let start = pos + rel;
+        if fenced.iter().any(|r| r.contains(&start)) {
+            pos = start + OPEN.len();
+            continue;
+        }
+        // An unterminated `<!--` is prose naming the marker far more often
+        // than it is a comment, and reading it as one would run every phrase
+        // rule across the rest of the document. Nothing after it can close
+        // either, so the scan is done.
+        let Some(rel_end) = source[start + OPEN.len()..].find(CLOSE) else {
+            break;
+        };
+        let end = start + OPEN.len() + rel_end + CLOSE.len();
+        let start_line = line_of.line(start);
+        let end_line = line_of.line(end.saturating_sub(1));
+        let text = source[start..end].to_string();
+
+        match blocks.last_mut() {
+            Some(prev) if prev.end_line + 1 == start_line => {
+                prev.end_line = end_line;
+                prev.text.push('\n');
+                prev.text.push_str(&text);
+            }
+            _ => blocks.push(CommentBlock {
+                start_line,
+                end_line,
+                text,
+                attached_code_lines: 0,
+                attached_code_text: None,
+                is_doc_comment: false,
+                is_markup: true,
+            }),
+        }
+        pos = end;
+    }
+    blocks
+}
+
+/// Byte offset to 1-indexed line number, over the sorted line starts.
+struct LineIndex {
+    line_starts: Vec<usize>,
+}
+
+impl LineIndex {
+    fn new(source: &str) -> Self {
+        let mut line_starts = vec![0usize];
+        for (i, b) in source.bytes().enumerate() {
+            if b == b'\n' {
+                line_starts.push(i + 1);
+            }
+        }
+        Self { line_starts }
+    }
+
+    fn line(&self, offset: usize) -> usize {
+        match self.line_starts.binary_search(&offset) {
+            Ok(i) => i + 1,
+            Err(i) => i,
+        }
     }
 }

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -7,6 +7,9 @@ pub enum Language {
     TypeScript,
     Hcl,
     Rust,
+    Html,
+    Yaml,
+    Markdown,
 }
 
 impl Language {
@@ -17,17 +20,25 @@ impl Language {
             Some("ts") | Some("tsx") => Some(Language::TypeScript),
             Some("tf") | Some("tfvars") | Some("hcl") => Some(Language::Hcl),
             Some("rs") => Some(Language::Rust),
+            Some("html") | Some("htm") => Some(Language::Html),
+            Some("yml") | Some("yaml") => Some(Language::Yaml),
+            Some("md") | Some("markdown") => Some(Language::Markdown),
             _ => None,
         }
     }
 
-    pub fn ts_language(&self) -> tree_sitter::Language {
+    /// The tree-sitter grammar for this language, or `None` for one whose
+    /// comments are found by a hand-rolled scanner instead.
+    pub fn ts_language(&self) -> Option<tree_sitter::Language> {
         match self {
-            Language::Python => tree_sitter_python::LANGUAGE.into(),
-            Language::JavaScript => tree_sitter_javascript::LANGUAGE.into(),
-            Language::TypeScript => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
-            Language::Hcl => tree_sitter_hcl::LANGUAGE.into(),
-            Language::Rust => tree_sitter_rust::LANGUAGE.into(),
+            Language::Python => Some(tree_sitter_python::LANGUAGE.into()),
+            Language::JavaScript => Some(tree_sitter_javascript::LANGUAGE.into()),
+            Language::TypeScript => Some(tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()),
+            Language::Hcl => Some(tree_sitter_hcl::LANGUAGE.into()),
+            Language::Rust => Some(tree_sitter_rust::LANGUAGE.into()),
+            Language::Html => Some(tree_sitter_html::LANGUAGE.into()),
+            Language::Yaml => Some(tree_sitter_yaml::LANGUAGE.into()),
+            Language::Markdown => None,
         }
     }
 
@@ -46,7 +57,18 @@ impl Language {
                     || trimmed.starts_with("/**")
                     || trimmed.starts_with("/*!")
             }
-            Language::Python | Language::Hcl => false,
+            Language::Python
+            | Language::Hcl
+            | Language::Html
+            | Language::Yaml
+            | Language::Markdown => false,
         }
+    }
+
+    /// Markup files carry prose and configuration rather than code. A
+    /// three-line comment above a one-line config key is idiomatic there,
+    /// so the length rule has no complexity budget to measure against.
+    pub fn is_markup(&self) -> bool {
+        matches!(self, Language::Html | Language::Yaml | Language::Markdown)
     }
 }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -189,9 +189,15 @@ fn hedge_language_rule(file: &str, block: &CommentBlock, config: &Config) -> Opt
 
 fn cross_file_ref_rule(file: &str, block: &CommentBlock) -> Option<Violation> {
     let re =
-        Regex::new(r"[A-Za-z0-9_./-]+\.(py|tf|ts|js|jsx|tsx|rs)(:\d+)?(::[A-Za-z_][A-Za-z0-9_]*)?")
+        Regex::new(
+            // Longest extension first: alternation is leftmost-first, so a
+            // shorter prefix listed earlier would truncate the reported path.
+            r"[A-Za-z0-9_./-]+\.(tfvars|yaml|html|jsx|tsx|hcl|htm|yml|py|tf|ts|js|rs|md)(:\d+)?(::[A-Za-z_][A-Za-z0-9_]*)?",
+        )
             .unwrap();
-    let m = re.find(&block.text)?;
+    let m = re
+        .find_iter(&block.text)
+        .find(|m| !is_inside_url(&block.text, m.start()))?;
 
     Some(Violation {
         file: file.to_string(),
@@ -207,8 +213,29 @@ fn cross_file_ref_rule(file: &str, block: &CommentBlock) -> Option<Violation> {
     })
 }
 
+/// True when a path-shaped match sits inside a URL. Documentation links
+/// ending in `.html`, `.md`, or a CDN script's `.js` are references to the
+/// wider world, not the in-repo pointers this rule is about.
+fn is_inside_url(text: &str, match_start: usize) -> bool {
+    // The whole whitespace-delimited token, not just what precedes the
+    // match: a path match inside `https://host/a.md` starts at the `//`,
+    // leaving only the scheme behind it.
+    let start = text[..match_start]
+        .char_indices()
+        .rev()
+        .find(|(_, c)| c.is_whitespace())
+        .map(|(i, c)| i + c.len_utf8())
+        .unwrap_or(0);
+    let end = text[match_start..]
+        .find(char::is_whitespace)
+        .map(|i| match_start + i)
+        .unwrap_or(text.len());
+    let token = &text[start..end];
+    token.contains("://") || token.contains("www.")
+}
+
 fn verbose_comment_rule(file: &str, block: &CommentBlock, config: &Config) -> Option<Violation> {
-    if block.is_doc_comment {
+    if block.is_doc_comment || block.is_markup {
         return None;
     }
     let line_count = block.end_line - block.start_line + 1;
@@ -423,6 +450,8 @@ fn strip_comment_markers(text: &str) -> String {
         rest
     } else if let Some(rest) = t.strip_prefix("/*") {
         rest.strip_suffix("*/").unwrap_or(rest)
+    } else if let Some(rest) = t.strip_prefix("<!--") {
+        rest.strip_suffix("-->").unwrap_or(rest)
     } else {
         t
     };

--- a/tests/fixtures/clean.yml
+++ b/tests/fixtures/clean.yml
@@ -1,0 +1,13 @@
+# Pinned because the orb syntax below requires 2.1.
+version: 2.1
+
+jobs:
+  build:
+    # trivy:ignore AVD-DS-0002 — this image runs as root by design.
+    description: "a # b no longer works"
+    # The runner reuses one container across steps, so anything writing
+    # to $HOME leaks into later steps. Everything here stays under the
+    # workspace.
+    # See https://circleci.com/docs/2.0/Executor%20Reference.html
+    steps:
+      - checkout

--- a/tests/fixtures/slop.html
+++ b/tests/fixtures/slop.html
@@ -1,0 +1,4 @@
+<!-- Was missing (SCA-533): the nav used to be hidden on mobile. -->
+<nav class="site-nav">
+  <a href="/">Home</a>
+</nav>

--- a/tests/fixtures/slop.md
+++ b/tests/fixtures/slop.md
@@ -1,0 +1,11 @@
+# Release notes
+
+<!-- Was missing (SCA-533): this section no longer renders without it. -->
+
+Real prose that stays.
+
+```html
+<!-- Was missing (SCA-901): sample markup, not a real comment. -->
+```
+
+More prose.

--- a/tests/fixtures/slop.yml
+++ b/tests/fixtures/slop.yml
@@ -1,0 +1,4 @@
+# Was missing (SCA-533): the deploy step no longer fails without this.
+# Root-caused to a stale layer; see pipeline.yml:42 for the old shape.
+steps:
+  - checkout

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -306,3 +306,198 @@ fn ticket_id_todo_exemption_can_be_disabled() {
         rules
     );
 }
+
+#[test]
+fn yaml_comment_flags_ticket_history_and_cross_file_ref() {
+    let source = include_str!("fixtures/slop.yml");
+    let violations = violations_for(source, Language::Yaml);
+    let rules: Vec<&str> = violations.iter().map(|v| v.rule).collect();
+
+    assert!(
+        rules.contains(&"TICKET_ID"),
+        "expected TICKET_ID, got {:?}",
+        rules
+    );
+    assert!(
+        rules.contains(&"HISTORY_NARRATION"),
+        "expected HISTORY_NARRATION, got {:?}",
+        rules
+    );
+    assert!(
+        rules.contains(&"CROSS_FILE_REF"),
+        "expected CROSS_FILE_REF, got {:?}",
+        rules
+    );
+}
+
+/// A `#` inside a quoted YAML scalar is data, not a comment — the reason
+/// this language goes through the grammar instead of a line scan.
+#[test]
+fn yaml_hash_inside_a_quoted_scalar_is_not_a_comment() {
+    let source = include_str!("fixtures/clean.yml");
+    let blocks = extract_blocks(source, Language::Yaml).unwrap();
+    assert!(
+        blocks.iter().all(|b| !b.text.contains("no longer works")),
+        "the quoted scalar was extracted as a comment: {:#?}",
+        blocks
+    );
+
+    let violations = violations_for(source, Language::Yaml);
+    assert!(
+        violations.is_empty(),
+        "expected zero violations on clean.yml, got {:#?}",
+        violations
+    );
+}
+
+#[test]
+fn html_comment_flags_ticket_and_history() {
+    let source = include_str!("fixtures/slop.html");
+    let violations = violations_for(source, Language::Html);
+    let rules: Vec<&str> = violations.iter().map(|v| v.rule).collect();
+
+    assert!(
+        rules.contains(&"TICKET_ID"),
+        "expected TICKET_ID, got {:?}",
+        rules
+    );
+    assert!(
+        rules.contains(&"HISTORY_NARRATION"),
+        "expected HISTORY_NARRATION, got {:?}",
+        rules
+    );
+}
+
+/// Markdown has no tree-sitter grammar wired up, so the scanner carries
+/// the whole burden of telling a real `<!-- -->` from one displayed as
+/// sample markup inside a fenced code block.
+#[test]
+fn markdown_flags_a_real_comment_but_not_one_inside_a_code_fence() {
+    let source = include_str!("fixtures/slop.md");
+    let blocks = extract_blocks(source, Language::Markdown).unwrap();
+    assert_eq!(
+        blocks.len(),
+        1,
+        "only the unfenced comment should be extracted, got {:#?}",
+        blocks
+    );
+    assert_eq!(blocks[0].start_line, 3);
+    assert_eq!(blocks[0].end_line, 3);
+
+    let violations = violations_for(source, Language::Markdown);
+    let rules: Vec<&str> = violations.iter().map(|v| v.rule).collect();
+    assert!(
+        rules.contains(&"TICKET_ID"),
+        "expected TICKET_ID, got {:?}",
+        rules
+    );
+    assert!(
+        rules.contains(&"HISTORY_NARRATION"),
+        "expected HISTORY_NARRATION, got {:?}",
+        rules
+    );
+    assert!(
+        violations.iter().all(|v| v.line == 3),
+        "the fenced comment must not be reported, got {:#?}",
+        violations
+    );
+}
+
+/// A multi-line comment keeps its true span, and two on consecutive lines
+/// read as one block — the same merge the tree-sitter path performs.
+#[test]
+fn markdown_spans_multiple_lines_and_merges_adjacent_comments() {
+    let source = "<!-- first\nstill first -->\n<!-- second -->\n\n<!-- separate -->\n";
+    let blocks = extract_blocks(source, Language::Markdown).unwrap();
+    assert_eq!(blocks.len(), 2, "got {:#?}", blocks);
+    assert_eq!((blocks[0].start_line, blocks[0].end_line), (1, 3));
+    assert_eq!((blocks[1].start_line, blocks[1].end_line), (5, 5));
+}
+
+/// Calibration against eight production repos found the length rule firing
+/// on the idiomatic config shape — a few lines of explanation above a
+/// one-line key — for 35 of 46 markup findings, while every real slop
+/// comment it sat on was already caught by a content rule.
+#[test]
+fn markup_is_exempt_from_the_length_rule_that_still_fires_on_code() {
+    let source = "# one\n# two\n# three\nkey = 1\n";
+
+    let python: Vec<&str> = violations_for(source, Language::Python)
+        .iter()
+        .map(|v| v.rule)
+        .collect();
+    assert!(
+        python.contains(&"VERBOSE_COMMENT"),
+        "the same shape must still fire on code, got {:?}",
+        python
+    );
+
+    let yaml: Vec<&str> = violations_for(source, Language::Yaml)
+        .iter()
+        .map(|v| v.rule)
+        .collect();
+    assert!(
+        !yaml.contains(&"VERBOSE_COMMENT"),
+        "markup must be exempt from the length rule, got {:?}",
+        yaml
+    );
+}
+
+/// A documentation link ending in `.html` or `.md` points at the wider
+/// world, not at a path in this repo that can rot.
+#[test]
+fn cross_file_ref_skips_a_url_but_still_flags_a_repo_path() {
+    let url = "# See https://circleci.com/docs/2.0/Executor%20Reference.html for the shape.\nversion: 2.1\n";
+    let rules: Vec<&str> = violations_for(url, Language::Yaml)
+        .iter()
+        .map(|v| v.rule)
+        .collect();
+    assert!(
+        !rules.contains(&"CROSS_FILE_REF"),
+        "a documentation URL is not a repo pointer, got {:?}",
+        rules
+    );
+
+    // A URL with no character outside the path charset is the harder case:
+    // the path match starts at the `//`, leaving only `https:` behind it.
+    let plain = "# See https://example.com/docs/guide.md for the shape.\nversion: 2.1\n";
+    let rules: Vec<&str> = violations_for(plain, Language::Yaml)
+        .iter()
+        .map(|v| v.rule)
+        .collect();
+    assert!(
+        !rules.contains(&"CROSS_FILE_REF"),
+        "a plain documentation URL is not a repo pointer, got {:?}",
+        rules
+    );
+
+    let path = "# Mirrors the bucket policy in modules/legacy/iam.tf.\nversion: 2.1\n";
+    let rules: Vec<&str> = violations_for(path, Language::Yaml)
+        .iter()
+        .map(|v| v.rule)
+        .collect();
+    assert!(
+        rules.contains(&"CROSS_FILE_REF"),
+        "a real in-repo path must still fire, got {:?}",
+        rules
+    );
+}
+
+/// Documentation about Markdown names the comment marker in prose. Reading
+/// an unterminated `<!--` as a comment would run the phrase rules across
+/// every line after it, turning ordinary prose into blocking errors.
+#[test]
+fn markdown_ignores_an_unterminated_comment_marker() {
+    let source =
+        "Use the `<!--` marker to open a comment.\n\nThe exporter no longer runs nightly.\n";
+    let blocks = extract_blocks(source, Language::Markdown).unwrap();
+    assert!(
+        blocks.is_empty(),
+        "an unterminated marker is prose, got {:#?}",
+        blocks
+    );
+    assert!(
+        violations_for(source, Language::Markdown).is_empty(),
+        "prose after an unterminated marker must not be checked"
+    );
+}


### PR DESCRIPTION
Extends windbag past code files to the markup formats that carry comments: YAML (`.yml`/`.yaml`), HTML (`.html`/`.htm`), and Markdown (`.md`/`.markdown`).

## How each is parsed

**YAML and HTML** go through tree-sitter grammars (`tree-sitter-yaml`, `tree-sitter-html`), so a `#` inside a quoted scalar stays data rather than becoming a comment — the reason YAML isn't line-scanned.

**Markdown** has no grammar wired up. `tree-sitter-md` needs a separate block/inline parser pair that doesn't fit the existing `set_language` path, and its `<!-- -->` lands in an `html_block` node shared with `<div>`/`<script>`. A fence-aware scan finds comments and leaves markup shown as an example inside a ``` fence alone — verified against a real 300-line `SKILL.md` where an unfenced slop comment fires and the identical one inside a ` ```html ` fence stays silent.

An unterminated `<!--` is **skipped**, not read as running to end of file. Prose naming the marker (`` use `<!--` to open a comment ``) is much likelier than a real unterminated comment, and reading it as one ran every phrase rule across the rest of the document — turning ordinary sentences like "the exporter no longer runs nightly" into commit-blocking errors.

## Calibration

Run against eight production repos (274 markup files), the first pass produced 46 findings — **35 of them VERBOSE_COMMENT**, nearly all the idiomatic config shape:

```yaml
# The runner reuses one container across steps, so anything
# writing to $HOME leaks into later steps.
steps:
```

A few lines of explanation above a one-line key is how config files are written, not a comment outgrowing its code — and in every case where real slop sat underneath, a content rule had already caught it independently. **Markup is now exempt from the length rule.** That drops the eight repos to 10 findings, all of which I spot-checked as true positives (a `SCA-469` ticket reference, two "no longer" narrations, seven real in-repo path pointers).

## Two changes that reach the existing languages

Worth a reviewer's attention, since the diff reads as "markup support":

1. **`CROSS_FILE_REF` extension list widened** to include `yaml`/`yml`/`html`/`htm`/`md`, and reordered longest-first so a `.tsx` path is reported whole instead of truncated at the `ts` alternative.
2. **Matches inside a URL no longer count.** Adding `.html`/`.md` surfaced documentation links as repo pointers (calibration hit `.../Executor%20Reference.html`). This fixes the same latent shape for existing languages — a CDN script's `.js` would have matched too.

## Known limits

- Inline code spans and 4-space indented code blocks aren't fence-tracked, so a `<!-- -->` shown either way in Markdown reads as a comment. Deliberate scope call; fenced blocks cover the common case.
- `OBVIOUS_COMMENT` is effectively inert on YAML — the grammar's sibling of a comment is the whole nested subtree, not the one key below it, so the attached-line count never lands in the 1–2 range the rule needs.
- TOML is one match arm away but out of scope here.

## Blast radius

The Claude Code plugin hook has no extension filter, so it now lints every `.md` and `.yml` Claude edits in any repo where it's installed. Practical impact is low (`<!-- -->` is rare in Markdown, and the noisy rule is exempt), but it is a real widening.

## Verification

- 21 integration tests pass (7 new), `cargo clippy --all-targets` clean, `windbag check --all` clean on this repo.
- `--new-only` smoke-tested on a scratch repo for both `.md` and `.yml` — the path the plugin's PostToolUse hook actually uses — reporting only newly added comments and leaving pre-existing ones alone.
- Calibration findings are encoded as fixtures: `clean.yml` carries the config shape, the quoted-scalar case, and a doc URL that must all stay quiet.