### PR TITLE
Check comments in SQL, including dbt and SQLMesh templates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,4 +7,4 @@ repos:
         entry: windbag check --staged
         language: system
         pass_filenames: false
-        types_or: [python, javascript, jsx, ts, tsx, terraform, rust, yaml, markdown, html]
+        types_or: [python, javascript, jsx, ts, tsx, terraform, rust, yaml, markdown, html, sql]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,4 +4,4 @@
   entry: windbag check --staged
   language: system
   pass_filenames: false
-  types_or: [python, javascript, jsx, ts, tsx, terraform, rust, yaml, markdown, html]
+  types_or: [python, javascript, jsx, ts, tsx, terraform, rust, yaml, markdown, html, sql]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # windbag
 
-A pre-commit linter that catches comments narrating a change — a ticket number, what the code used to do, hedging about whether it works — instead of documenting why the current code is the way it is. Checks Python, JavaScript/TypeScript, Terraform/HCL, and Rust, plus the markup formats that carry comments: YAML, HTML, and Markdown.
+A pre-commit linter that catches comments narrating a change — a ticket number, what the code used to do, hedging about whether it works — instead of documenting why the current code is the way it is. Checks Python, JavaScript/TypeScript, Terraform/HCL, Rust, and SQL (including dbt and SQLMesh templates), plus the markup formats that carry comments: YAML, HTML, and Markdown.
 
 ## What it detects
 
@@ -26,6 +26,18 @@ The content rules — `TICKET_ID`, `HISTORY_NARRATION`, `HEDGE_LANGUAGE`,
 `CROSS_FILE_REF` — carry the weight here. `VERBOSE_COMMENT` does not apply:
 a few lines of explanation above a one-line config key is the idiomatic
 shape in a config file, not a comment outgrowing its code.
+
+## SQL files
+
+`.sql` files are read as Jinja-templated SQL, which is what dbt and SQLMesh
+models are. `--`, `/* */`, and Jinja `{# ... #}` comments are all checked. A
+marker inside a `'string'`, a `"quoted identifier"`, a `$$ ... $$` body, or a
+`{{ ... }}` / `{% ... %}` tag is data the template emits, not a comment. The
+scanner is dialect-agnostic, so Snowflake, Postgres, BigQuery, and the rest
+all work; MySQL-style `#` line comments are the one form it does not read.
+
+A comment is measured against the statement below it: the non-blank lines
+that follow, through the first one ending in `;`.
 
 ## Install
 
@@ -64,7 +76,7 @@ Pre-commit:
       entry: windbag check --staged
       language: system
       pass_filenames: false
-      types_or: [python, javascript, jsx, ts, tsx, terraform, rust, yaml, markdown, html]
+      types_or: [python, javascript, jsx, ts, tsx, terraform, rust, yaml, markdown, html, sql]
 ```
 
 (`windbag` needs to already be on `PATH` — `language: system` doesn't install it for you.)

--- a/src/comments.rs
+++ b/src/comments.rs
@@ -45,7 +45,10 @@ pub fn extract_blocks(source: &str, language: Language) -> anyhow::Result<Vec<Co
         Some(ts_language) => extract_treesitter_blocks(source, &ts_language, language),
         // Markdown, whose `<!-- -->` shares an `html_block` node with
         // `<div>`/`<script>` in the grammar and needs a sharper separation.
-        None => Ok(scan_html_comments(source)),
+        None if language == Language::Markdown => Ok(scan_html_comments(source)),
+        // SQL, which in practice is a dbt or SQLMesh template that no SQL
+        // grammar parses cleanly.
+        None => Ok(crate::sql::scan_sql_comments(source)),
     }
 }
 
@@ -246,12 +249,12 @@ fn scan_html_comments(source: &str) -> Vec<CommentBlock> {
 }
 
 /// Byte offset to 1-indexed line number, over the sorted line starts.
-struct LineIndex {
+pub(crate) struct LineIndex {
     line_starts: Vec<usize>,
 }
 
 impl LineIndex {
-    fn new(source: &str) -> Self {
+    pub(crate) fn new(source: &str) -> Self {
         let mut line_starts = vec![0usize];
         for (i, b) in source.bytes().enumerate() {
             if b == b'\n' {
@@ -261,7 +264,7 @@ impl LineIndex {
         Self { line_starts }
     }
 
-    fn line(&self, offset: usize) -> usize {
+    pub(crate) fn line(&self, offset: usize) -> usize {
         match self.line_starts.binary_search(&offset) {
             Ok(i) => i + 1,
             Err(i) => i,

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -10,6 +10,7 @@ pub enum Language {
     Html,
     Yaml,
     Markdown,
+    Sql,
 }
 
 impl Language {
@@ -23,6 +24,7 @@ impl Language {
             Some("html") | Some("htm") => Some(Language::Html),
             Some("yml") | Some("yaml") => Some(Language::Yaml),
             Some("md") | Some("markdown") => Some(Language::Markdown),
+            Some("sql") => Some(Language::Sql),
             _ => None,
         }
     }
@@ -38,7 +40,7 @@ impl Language {
             Language::Rust => Some(tree_sitter_rust::LANGUAGE.into()),
             Language::Html => Some(tree_sitter_html::LANGUAGE.into()),
             Language::Yaml => Some(tree_sitter_yaml::LANGUAGE.into()),
-            Language::Markdown => None,
+            Language::Markdown | Language::Sql => None,
         }
     }
 
@@ -61,7 +63,8 @@ impl Language {
             | Language::Hcl
             | Language::Html
             | Language::Yaml
-            | Language::Markdown => false,
+            | Language::Markdown
+            | Language::Sql => false,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub mod git;
 pub mod lang;
 pub mod output;
 pub mod rules;
+pub mod sql;

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1,0 +1,141 @@
+//! Comment extraction for SQL files.
+//!
+//! The files this sees are mostly dbt and SQLMesh models: SQL wrapped in
+//! Jinja, which no SQL grammar parses cleanly. A parse-error-riddled tree
+//! still yields the comments, but its statement boundaries fall apart, and
+//! the length rule measured against a lone `with` keyword misfires. A
+//! scanner that knows the three comment forms and the four things that
+//! can hide a marker gives the same comments with a statement boundary
+//! that holds up.
+
+use crate::comments::{CommentBlock, LineIndex};
+
+/// Extracts `--`, `/* */`, and Jinja `{# #}` comments, ignoring markers
+/// inside `'...'` strings, `"..."` quoted identifiers, `$$...$$` bodies,
+/// and `{{ }}` / `{% %}` Jinja tags, whose contents the template emits as
+/// SQL rather than reads as SQL. Comments on consecutive lines merge into
+/// one block. An unterminated `/*` or `{#` is a syntax error in the file,
+/// and reading it as a comment would run every rule across the rest of
+/// the source, so the scan stops there.
+pub fn scan_sql_comments(source: &str) -> Vec<CommentBlock> {
+    let line_of = LineIndex::new(source);
+    let mut blocks: Vec<CommentBlock> = Vec::new();
+
+    for (start, end) in comment_spans(source) {
+        let start_line = line_of.line(start);
+        let end_line = line_of.line(end.saturating_sub(1));
+        let text = &source[start..end];
+        match blocks.last_mut() {
+            Some(prev) if prev.end_line + 1 == start_line => {
+                prev.end_line = end_line;
+                prev.text.push('\n');
+                prev.text.push_str(text);
+            }
+            _ => blocks.push(CommentBlock {
+                start_line,
+                end_line,
+                text: text.to_string(),
+                attached_code_lines: 0,
+                attached_code_text: None,
+                is_doc_comment: false,
+                is_markup: false,
+            }),
+        }
+    }
+
+    let lines: Vec<&str> = source.lines().collect();
+    for block in &mut blocks {
+        let (count, text) = attached_statement(&lines, block.end_line);
+        block.attached_code_lines = count;
+        block.attached_code_text = text;
+    }
+    blocks
+}
+
+/// Byte spans of each comment, in source order.
+fn comment_spans(source: &str) -> Vec<(usize, usize)> {
+    let bytes = source.as_bytes();
+    let mut spans = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        let rest = &source[i..];
+        if rest.starts_with("--") {
+            let end = rest.find('\n').map(|n| i + n).unwrap_or(bytes.len());
+            spans.push((i, end));
+            i = end;
+        } else if rest.starts_with("/*") {
+            let Some(end) = delimited_end(source, i, "/*", "*/") else {
+                break;
+            };
+            spans.push((i, end));
+            i = end;
+        } else if rest.starts_with("{#") {
+            let Some(end) = delimited_end(source, i, "{#", "#}") else {
+                break;
+            };
+            spans.push((i, end));
+            i = end;
+        } else if rest.starts_with("{{") {
+            i = delimited_end(source, i, "{{", "}}").unwrap_or(source.len());
+        } else if rest.starts_with("{%") {
+            i = delimited_end(source, i, "{%", "%}").unwrap_or(source.len());
+        } else if rest.starts_with("$$") {
+            i = delimited_end(source, i, "$$", "$$").unwrap_or(source.len());
+        } else if bytes[i] == b'\'' || bytes[i] == b'"' {
+            i = skip_quoted(bytes, i);
+        } else {
+            i += 1;
+        }
+    }
+    spans
+}
+
+/// Offset just past the `close` matching the `open` at `at`, or `None`
+/// when the source ends first.
+fn delimited_end(source: &str, at: usize, open: &str, close: &str) -> Option<usize> {
+    let body = at + open.len();
+    source[body..].find(close).map(|n| body + n + close.len())
+}
+
+/// Offset just past the closing quote of the string or quoted identifier
+/// opening at `open`. A doubled quote is an escaped quote, and so is a
+/// backslash-escaped one (Snowflake and MySQL accept the latter).
+fn skip_quoted(bytes: &[u8], open: usize) -> usize {
+    let quote = bytes[open];
+    let mut i = open + 1;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' {
+            i += 2;
+        } else if bytes[i] == quote {
+            if bytes.get(i + 1) == Some(&quote) {
+                i += 2;
+            } else {
+                return i + 1;
+            }
+        } else {
+            i += 1;
+        }
+    }
+    bytes.len()
+}
+
+/// The statement a comment block sits above: the non-blank lines following
+/// it, through the first one that ends in `;`. Nothing when the next line
+/// is blank or the block ends the file.
+fn attached_statement(lines: &[&str], block_end_line: usize) -> (usize, Option<String>) {
+    let mut taken: Vec<&str> = Vec::new();
+    for line in lines.iter().skip(block_end_line) {
+        if line.trim().is_empty() {
+            break;
+        }
+        taken.push(line);
+        if line.trim_end().ends_with(';') {
+            break;
+        }
+    }
+    if taken.is_empty() {
+        (0, None)
+    } else {
+        (taken.len(), Some(taken.join("\n")))
+    }
+}

--- a/tests/fixtures/slop.sql
+++ b/tests/fixtures/slop.sql
@@ -1,0 +1,24 @@
+{{ config(materialized='incremental', unique_key='id') }}
+
+{# Was missing (SCA-533): the merge used to double count. #}
+
+-- Was missing (SCA-700): this used to silently drop nulls.
+with src as (
+    select
+        id,
+        'a -- not a comment' as literal_dashes,
+        '/* not a comment */' as literal_block,
+        {{ "-- not a comment either" }} as jinja_expr,
+        dt
+    from {{ ref('raw_events') }}
+    {% if is_incremental() %}
+    where dt > (select max(dt) from {{ this }})
+    {% endif %}
+),
+/* This should work but I'm not sure why the dedupe fails sometimes. */
+final as (
+    select * from src
+    qualify row_number() over (partition by id order by dt desc) = 1
+)
+-- Sorted DESC because the caller assumes the first row is newest.
+select * from final order by dt desc

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -501,3 +501,123 @@ fn markdown_ignores_an_unterminated_comment_marker() {
         "prose after an unterminated marker must not be checked"
     );
 }
+
+#[test]
+fn sql_extension_maps_to_the_sql_language() {
+    assert_eq!(
+        Language::from_path(Path::new("models/x.sql")),
+        Some(Language::Sql)
+    );
+}
+
+/// dbt and SQLMesh models are Jinja-templated SQL: `--` and `/* */`
+/// comments sit next to `{# #}` Jinja comments, and all three carry the
+/// same kind of slop.
+#[test]
+fn sql_flags_slop_in_line_block_and_jinja_comments() {
+    let source = include_str!("fixtures/slop.sql");
+    let blocks = extract_blocks(source, Language::Sql).unwrap();
+    let lines: Vec<usize> = blocks.iter().map(|b| b.start_line).collect();
+    assert_eq!(lines, vec![3, 5, 18, 23], "got {:#?}", blocks);
+
+    let violations = violations_for(source, Language::Sql);
+    let at = |line: usize| -> Vec<&str> {
+        violations
+            .iter()
+            .filter(|v| v.line == line)
+            .map(|v| v.rule)
+            .collect()
+    };
+    for line in [3, 5] {
+        assert!(
+            at(line).contains(&"TICKET_ID"),
+            "line {line}: {:?}",
+            at(line)
+        );
+        assert!(
+            at(line).contains(&"HISTORY_NARRATION"),
+            "line {line}: {:?}",
+            at(line)
+        );
+    }
+    assert!(at(18).contains(&"HEDGE_LANGUAGE"), "line 18: {:?}", at(18));
+    assert!(
+        at(23).is_empty(),
+        "the real WHY comment must be clean, got {:?}",
+        at(23)
+    );
+}
+
+/// A `--` or `/* */` inside a string literal, or inside a `{{ }}` Jinja
+/// expression, is data the template emits, not a comment.
+#[test]
+fn sql_comment_markers_inside_strings_and_jinja_are_not_comments() {
+    let source = include_str!("fixtures/slop.sql");
+    let blocks = extract_blocks(source, Language::Sql).unwrap();
+    assert!(
+        blocks.iter().all(|b| !b.text.contains("not a comment")),
+        "a literal was extracted as a comment: {:#?}",
+        blocks
+    );
+
+    let dollar = "select $$ -- not a comment $$ as s;\n";
+    let blocks = extract_blocks(dollar, Language::Sql).unwrap();
+    assert!(blocks.is_empty(), "got {:#?}", blocks);
+
+    let escaped = "select 'it''s -- not a comment' as s;\n";
+    let blocks = extract_blocks(escaped, Language::Sql).unwrap();
+    assert!(blocks.is_empty(), "got {:#?}", blocks);
+}
+
+/// SQL has no braces to mislead a line scan, and a statement ends at a
+/// blank line or a `;`, so that is the code a comment is measured against.
+#[test]
+fn sql_attached_code_runs_to_a_blank_line_or_semicolon() {
+    let to_semicolon = "-- why\nselect 1\nfrom t\nwhere x = 1;\nselect 2\n";
+    let blocks = extract_blocks(to_semicolon, Language::Sql).unwrap();
+    assert_eq!(blocks.len(), 1, "got {:#?}", blocks);
+    assert_eq!(blocks[0].attached_code_lines, 3);
+    assert_eq!(
+        blocks[0].attached_code_text.as_deref(),
+        Some("select 1\nfrom t\nwhere x = 1;")
+    );
+
+    let to_blank = "-- why\nselect 1\nfrom t\n\nselect 2\n";
+    let blocks = extract_blocks(to_blank, Language::Sql).unwrap();
+    assert_eq!(blocks[0].attached_code_lines, 2);
+
+    let floating = "-- why\n\nselect 1\n";
+    let blocks = extract_blocks(floating, Language::Sql).unwrap();
+    assert_eq!(blocks[0].attached_code_lines, 0);
+    assert_eq!(blocks[0].attached_code_text, None);
+}
+
+/// SQL is code, not markup: the length rule and the restatement rule both
+/// apply, the way they do for Python.
+#[test]
+fn sql_is_subject_to_the_length_and_restatement_rules() {
+    let verbose = "-- one\n-- two\n-- three\nselect 1\n";
+    let rules: Vec<&str> = violations_for(verbose, Language::Sql)
+        .iter()
+        .map(|v| v.rule)
+        .collect();
+    assert!(rules.contains(&"VERBOSE_COMMENT"), "got {:?}", rules);
+
+    let obvious = "-- create the users table\ncreate table users (id int)\n";
+    let rules: Vec<&str> = violations_for(obvious, Language::Sql)
+        .iter()
+        .map(|v| v.rule)
+        .collect();
+    assert!(rules.contains(&"OBVIOUS_COMMENT"), "got {:?}", rules);
+}
+
+/// A block comment keeps its true span, and adjacent comments of any
+/// flavor on consecutive lines merge into one block.
+#[test]
+fn sql_multiline_block_comment_merges_with_an_adjacent_line_comment() {
+    let source = "/* first\nstill first */\n-- second\n{# third #}\n\n-- separate\nselect 1\n";
+    let blocks = extract_blocks(source, Language::Sql).unwrap();
+    assert_eq!(blocks.len(), 2, "got {:#?}", blocks);
+    assert_eq!((blocks[0].start_line, blocks[0].end_line), (1, 4));
+    assert_eq!((blocks[1].start_line, blocks[1].end_line), (6, 6));
+}


### PR DESCRIPTION
## Summary

- Adds `Language::Sql` for `.sql` files, treated as code so all six rules apply.
- New `src/sql.rs` scanner extracts `--`, `/* */`, and Jinja `{# #}` comments, skipping markers inside `'strings'` (`''` and `\'` escapes), `"quoted identifiers"`, `$$ ... $$` bodies, and `{{ }}` / `{% %}` Jinja tags.
- Attached code is measured by a raw line scan through the first line ending in `;`, which is what avoids the false `VERBOSE_COMMENT` positives a tree-sitter grammar produces on Jinja-fragmented trees.
- `sql` added to the pre-commit `types_or` lists; README documents the SQL behavior and the one gap (MySQL `#` comments).

## Why a scanner, not a grammar

A spike with `tree-sitter-sequel` on a Snowflake dbt model extracted the comments fine, but the parse errors from Jinja made the "next sibling" of a comment above a CTE the bare `with` keyword. A three-line comment there would trip the length rule at 3.0x against one line, and the Claude Code hook blocks on that by default. The grammar would only have contributed string-literal skipping, which the scanner does itself.

## Test plan

- [x] Six new integration tests plus a `slop.sql` dbt/Snowflake fixture, written first and watched fail
- [x] `cargo test`: 27 passed
- [x] `cargo fmt --check` and `cargo clippy --all-targets` clean
- [x] Binary on the fixture flags exactly the expected `TICKET_ID`, `HISTORY_NARRATION`, and `HEDGE_LANGUAGE` errors, nothing on string literals or the clean "why" comment
- [x] `windbag check --all` on the repo itself is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)