### PR TITLE
Fix org name and internal repo references ahead of open-sourcing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 description = "Anti-slop linter: catches AI-generated comments that narrate change history instead of explaining a real constraint"
 license = "MIT"
-repository = "https://github.com/scalevp-investment-ops/windbag"
+repository = "https://github.com/scale-venture-partners/windbag"
 
 [lib]
 name = "windbag"

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ blocking error and it rewrites the comment before moving on. A `SessionStart`
 hook states the rules up front so most edits never trip the linter at all.
 
 ```
-/plugin marketplace add scalevp-investment-ops/windbag
+/plugin marketplace add scale-venture-partners/windbag
 /plugin install windbag@windbag
 ```
 
@@ -99,7 +99,7 @@ and they exit quietly when they can't find it. That means a Rust toolchain
 (see [Install](#install)) plus:
 
 ```bash
-cargo install --git https://github.com/scalevp-investment-ops/windbag
+cargo install --git https://github.com/scale-venture-partners/windbag
 ```
 
 TODO: publish prebuilt macOS binaries from a tagged release so installing this
@@ -114,7 +114,7 @@ marketplace, and the hooks apply from their next session:
 {
   "extraKnownMarketplaces": {
     "windbag": {
-      "source": { "source": "github", "repo": "scalevp-investment-ops/windbag" }
+      "source": { "source": "github", "repo": "scale-venture-partners/windbag" }
     }
   },
   "enabledPlugins": { "windbag@windbag": true }

--- a/tests/fixtures/clean.tf
+++ b/tests/fixtures/clean.tf
@@ -10,7 +10,7 @@ resource "aws_wafv2_web_acl" "main" {
   }
 }
 
-# svp-web-cache — VPC Lattice service-to-service connectivity (used by the agent worker)
+# VPC Lattice service-to-service connectivity for the cache tier
 resource "aws_vpc_lattice_service" "cache" {
   name = "cache"
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14,9 +14,9 @@ fn violations_for(source: &str, language: Language) -> Vec<windbag::rules::Viola
         .collect()
 }
 
-/// Paraphrase of the real pattern from scalevp-investment-ops/svp-infra-shared
-/// PR #308 that motivated this tool: a comment narrating a ticket number,
-/// the bug's prior-broken behavior, and a pointer into another file.
+/// Paraphrase of the pattern that motivated this tool: a comment narrating
+/// a ticket number, the bug's prior-broken behavior, and a pointer into
+/// another file.
 #[test]
 fn flags_ticket_history_and_cross_file_ref_together() {
     let source = include_str!("fixtures/slop.tf");


### PR DESCRIPTION
## Summary
- Cargo.toml and README pointed at the `scalevp-investment-ops` org, which doesn't match the actual GitHub remote (`scale-venture-partners`) — this broke the `/plugin marketplace add`, `cargo install --git`, and `extraKnownMarketplaces` instructions.
- Genericized a test doc-comment and a fixture comment that named a real internal repo (`svp-infra-shared`) and PR number — no functional change, test coverage is unaffected.

## Not addressed here (needs a decision, not a forward commit)
Several commit messages in this repo's history (`5d45e2b`, `a2adcc8`, `3867a3c`, `77fcf36`) name internal ScaleVP repos (svp-mcp, svp-chat, svp-deal-scoring, svp-portal, svp-infra-shared) and quote internal phrases used as calibration data while developing the linter's rules. A forward PR can't remove those — they only go away if this is published from a fresh/squashed history rather than by flipping this repo public as-is. Flagging separately since that's a history rewrite, not a content fix.

`examples/scalevp.toml` (shows ScaleVP's own config, including our real Linear ticket prefix) was left as-is — this repo is being open-sourced under ScaleVP's own name, so an example of our own dogfooded usage seems fine to keep, but flagging in case you'd rather genericize it too.

## Test plan
- [x] `cargo test` — all 29 tests pass