### PR TITLE
Package as a Python wheel via maturin's bin-bindings mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ cargo install --path .
 
 That puts `windbag` in `~/.cargo/bin`, which must be on your `PATH`.
 
+Without wanting `windbag` on `PATH` permanently: this repo also builds as a
+Python package via [maturin](https://www.maturin.rs)'s `bindings = "bin"`
+mode, which just wraps the compiled binary in a wheel — there's no Python
+code here, and `import windbag` doesn't work. From a checkout with a Rust
+toolchain and [uv](https://docs.astral.sh/uv/):
+
+```bash
+uvx maturin build --release
+uvx --from target/wheels/windbag-*.whl windbag check --all
+```
+
+No package is published yet, so this only works from a local build for now
+— `uvx windbag` (pulling from an index) isn't available.
+
 ## Use
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["maturin>=1.7,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "windbag"
+version = "0.1.0"
+description = "Catches comments that narrate a change instead of documenting a real constraint"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.8"
+
+[project.urls]
+Repository = "https://github.com/scale-venture-partners/windbag"
+
+[tool.maturin]
+bindings = "bin"
+strip = true


### PR DESCRIPTION
## Summary
- Adds `pyproject.toml` using maturin's `bindings = "bin"` mode, which wraps the compiled `windbag` binary in a wheel with no Python bindings/code involved.
- Verified locally: `uvx maturin build --release` produces a working wheel, and `uvx --from target/wheels/windbag-*.whl windbag ...` runs it correctly.
- No package is published anywhere yet (not on PyPI, not on internal CodeArtifact) — this only adds the packaging and documents the local-build workflow in the README.

## Test plan
- [x] `cargo test` passes
- [x] `cargo fmt --check` passes
- [x] `uvx maturin build --release` builds a wheel
- [x] `uvx --from <wheel> windbag --version` and `windbag check --all` run correctly